### PR TITLE
개발환경과 운영환경 profile 나누기 

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,1 +1,30 @@
+spring:
+  profiles:
+    active: local # default
+    group:
+      local:
+        - common
+      prod:
+        - common
 
+---
+spring:
+  config:
+    activate:
+      on-profile: common
+
+# ...
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: local
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod


### PR DESCRIPTION
개발환경과 운영환경에서 공통으로 사용되는 부분은 common으로 사용하고 나머지는 분리하였다. 이를 group 키워드를 사용하여 같이 실행되도록 함.

This closes #9 