### PR TITLE
kakao 주소검색 API 구현하기

### DIFF
--- a/src/main/java/com/example/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/api/dto/DocumentDto.java
@@ -1,0 +1,21 @@
+package com.example.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DocumentDto {
+
+    @JsonProperty("address_name")
+    private String addressName;     // 전체 지번 주소 또는 전체 도로명 주소, 입력에 따라 결정됨
+
+    @JsonProperty("y")
+    private double latitude;        // 위도(latitude)
+
+    @JsonProperty("x")
+    private double longitude;       // 경도(longitude)
+}

--- a/src/main/java/com/example/api/dto/KakaoApiResponseDto.java
+++ b/src/main/java/com/example/api/dto/KakaoApiResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoApiResponseDto {
+
+    private MetaDto metaDto;
+
+    private List<DocumentDto> documentList;
+}

--- a/src/main/java/com/example/api/dto/MetaDto.java
+++ b/src/main/java/com/example/api/dto/MetaDto.java
@@ -1,0 +1,15 @@
+package com.example.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MetaDto {
+
+    @JsonProperty("total_count")
+    private Integer totalCount;     // 검색어에 검색된 문서 수
+}

--- a/src/main/java/com/example/api/service/KakaoAddressSearchService.java
+++ b/src/main/java/com/example/api/service/KakaoAddressSearchService.java
@@ -1,0 +1,41 @@
+package com.example.api.service;
+
+import com.example.api.dto.KakaoApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoAddressSearchService {
+
+    private final RestTemplate restTemplate;
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+
+    @Value("${kakao.rest.api.key}")
+    private String kakaoRestApiKey;
+
+    public KakaoApiResponseDto requestAddressSearch(String address) {
+
+        if (ObjectUtils.isEmpty(address)) return null;
+
+        URI uri = kakaoUriBuilderService.buildUriByAddressSearch(address);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK" + kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        // kakao api 호출
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+
+}

--- a/src/main/java/com/example/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/com/example/api/service/KakaoUriBuilderService.java
@@ -1,0 +1,24 @@
+package com.example.api.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+public class KakaoUriBuilderService {
+
+    private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+
+    public URI buildUriByAddressSearch(String address) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
+        uriBuilder.queryParam("query", address);
+
+        URI uri = uriBuilder.build().encode().toUri();
+        log.info("[KakaoUriBuilderService - buildUriByAddressSearch] address : {}, uri: {}", address, uri);
+
+        return uri;
+    }
+}

--- a/src/main/java/com/example/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.example.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,10 @@ spring:
     activate:
       on-profile: common
 
-# ...
+kakao:
+  rest:
+    api:
+      key: ${KAKAO_REST_API_KEY}
 
 ---
 


### PR DESCRIPTION
kakao 주소검색 api 구현을 완료하였다.

공식문서를 참조하여 Response에서 필요한 값에 대한 Dto를 만들었다.

This closes #14 

## Reference
* [카카오 Rest API 공식문서](https://developers.kakao.com/docs/latest/ko/local/dev-guide)