### PR TITLE
Spring retry 구현 및 검증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	// spring-retry
+	implementation 'org.springframework.retry:spring-retry'
+
 	compileOnly 'org.projectlombok:lombok'
 
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -45,6 +48,10 @@ dependencies {
 	// testcontainers
 	testImplementation 'org.testcontainers:spock:1.17.1'
 	testImplementation 'org.testcontainers:mariadb:1.17.1'
+
+	// mockWebServer
+	testImplementation 'com.squareup.okhttp3:okhttp:4.10.0'
+	testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/api/service/KakaoAddressSearchService.java
+++ b/src/main/java/com/example/api/service/KakaoAddressSearchService.java
@@ -7,6 +7,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.RestTemplate;
@@ -24,6 +27,11 @@ public class KakaoAddressSearchService {
     @Value("${kakao.rest.api.key}")
     private String kakaoRestApiKey;
 
+    @Retryable(
+            value = {RuntimeException.class},
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 2000)
+    )
     public KakaoApiResponseDto requestAddressSearch(String address) {
 
         if (ObjectUtils.isEmpty(address)) return null;
@@ -36,6 +44,13 @@ public class KakaoAddressSearchService {
 
         // kakao api 호출
         return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+
+    @Recover
+    public KakaoApiResponseDto recover(RuntimeException e, String address) {
+        log.error("All the retries failed. address: {}, error: {}", address, e.getMessage());
+
+        return null;
     }
 
 }

--- a/src/main/java/com/example/config/RetryConfig.java
+++ b/src/main/java/com/example/config/RetryConfig.java
@@ -1,0 +1,18 @@
+package com.example.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.support.RetryTemplate;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+
+//    RetryTemplate 를 사용할 경우
+//    @Bean
+//    public RetryTemplate retryTemplate() {
+//        return new RetryTemplate();
+//    }
+
+}

--- a/src/test/groovy/com/example/api/service/KakaoAddressSearchServiceRetryTest.groovy
+++ b/src/test/groovy/com/example/api/service/KakaoAddressSearchServiceRetryTest.groovy
@@ -1,0 +1,78 @@
+package com.example.api.service
+
+import com.example.AbstractIntegrationContainerBaseTest
+import com.example.api.dto.KakaoApiResponseDto
+import com.example.api.dto.MetaDto
+import com.example.api.dto.DocumentDto
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+
+class KakaoAddressSearchServiceRetryTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired  private KakaoAddressSearchService kakaoAddressSearchService
+
+    @SpringBean private KakaoUriBuilderService kakaoUriBuilderService = Mock()
+
+    private MockWebServer mockWebServer
+
+    private ObjectMapper mapper = new ObjectMapper()
+
+    private String inputAddress = "서울 성북구 종암로 10길"
+
+    def setup() {
+        mockWebServer = new MockWebServer()
+        mockWebServer.start()
+        println mockWebServer.port
+        println mockWebServer.url("/")
+    }
+
+    def cleanup() {
+        mockWebServer.shutdown()
+    }
+
+    def "requestAddressSearch retry success"() {
+        given:
+        def metaDto = new MetaDto(1)
+        def documentDto = DocumentDto.builder()
+                .addressName(inputAddress)
+                .build()
+        def expectedResponse = new KakaoApiResponseDto(metaDto, Arrays.asList(documentDto))
+        def uri = mockWebServer.url("/").uri()
+
+        when:
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(mapper.writeValueAsString(expectedResponse)))
+
+        def kakaoApiResult = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+        kakaoApiResult.getDocumentList().size() == 1
+        kakaoApiResult.getMetaDto().totalCount == 1
+        kakaoApiResult.getDocumentList().get(0).getAddressName() == inputAddress
+
+    }
+
+
+    def "requestAddressSearch retry fail "() {
+        given:
+        def uri = mockWebServer.url("/").uri()
+
+        when:
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+
+        def result = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+        result == null
+    }
+}


### PR DESCRIPTION
외부 API를 사용하는 부분을 Spring Retry를 통해 시스템 안정성을 높이고
Retry가 정상적으로 작동함을 검증하기 위해 mockwebserver을 사용하였다.

This closes #38 